### PR TITLE
chore: add react and react-dom in deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,5 +10,9 @@
   },
   "devDependencies": {
     "vite": "^5.2.0",
+  },
+  "dependencies": {
+    "react": "the-react-package-version-in-your-react-code",
+    "react-dom": "the-react0-dom-package-version-in-your-react-code"
   }
 }


### PR DESCRIPTION
React and react-dom are added in dependencies. But the version numbers are not specified